### PR TITLE
Allow configuration so we do not need class_eval in wf-student

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@ Define a `current_user` in your `application_controller.rb`:
 
 ```ruby
 class ApplicationController < ActionController::Base
-  # ...
-
-  private
-
   def current_user
     # Your own implementation
   end

--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Define a `current_user` in your `application_controller.rb`:
 
 ```ruby
 class ApplicationController < ActionController::Base
+    # ...
 
     private
+
     def current_user
       # Your own implementation
     end
@@ -60,6 +62,7 @@ Add the following to `user.rb`:
 
 ```ruby
 class User < ActiveRecord::Base
+  include Discuss::Models::Discussable
   acts_as_discussable
 end
 ```

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ Define a `current_user` in your `application_controller.rb`:
 
 ```ruby
 class ApplicationController < ActionController::Base
-    # ...
+  # ...
 
-    private
+  private
 
-    def current_user
-      # Your own implementation
-    end
+  def current_user
+    # Your own implementation
   end
 end
 ```

--- a/app/controllers/discuss/application_controller.rb
+++ b/app/controllers/discuss/application_controller.rb
@@ -27,7 +27,7 @@ module Discuss
     end
 
     def recipient_classes
-      ActiveRecord::Base.descendants.select { |c| c.included_modules.include? Discuss::Models::Discussable }
+      Discuss.model_base.descendants.select { |c| c.included_modules.include? Discuss::Models::Discussable }
     end
 
     def recipient_json(r)

--- a/app/models/discuss/message.rb
+++ b/app/models/discuss/message.rb
@@ -43,7 +43,7 @@ module Discuss
     scope :not_deleted,  -> { where('deleted_at is NULL') }
 
     scope :by_user, -> (user) { where(user: user) }
-    scope :inbox,   -> (user) { ::Discuss::Message.inbox_scope(self, user) }
+    scope :inbox,   -> (user) { ::Discuss::Message.inbox_scope.call(self, user) }
     scope :outbox,  -> (user) { by_user(user).active.sent }
     scope :drafts,  -> (user) { by_user(user).active.draft.not_received }
     scope :trash,   -> (user) { by_user(user).trashed.not_deleted }

--- a/lib/discuss.rb
+++ b/lib/discuss.rb
@@ -2,4 +2,16 @@ require 'redcarpet'
 require 'discuss/engine'
 require 'discuss/models/discussable'
 
-ActiveRecord::Base.extend Discuss::Models::Discussable
+module Discuss
+  class << self
+    attr_writer :model_base
+
+    def model_base
+      if defined?(@model_base)
+        @model_base
+      else
+        ActiveRecord::Base
+      end
+    end
+  end
+end

--- a/lib/discuss.rb
+++ b/lib/discuss.rb
@@ -4,14 +4,44 @@ require 'discuss/models/discussable'
 
 module Discuss
   class << self
+    # Override the default base class all Discuss models inherit from.
+    # This is useful if you want to inherit from an abstract class
+    # that calls `connects_to`, for example.
+    #
+    # The default value is `ActiveRecord::Base`.
+    #
+    #     Discuss.model_base = ActiveRecord
+    #
+    # or
+    #
+    #     Discuss.model_base = MyOtherDatabase::ActiveRecord
+    #
+    # The default value is:
+    #
+    #     ActiveRecord::Base
+    #
     attr_writer :model_base
 
+    # Override the default message inbox scope:
+    #
+    #     Discuss.inbox_scope = -> (messages, user) {
+    #       messages.by_user(user).active.received.my_filter
+    #     }
+    #
+    # The default value is:
+    #
+    #     -> (messages, user) {
+    #       messages.by_user(user).active.received
+    #     }
+    #
+    attr_writer :inbox_scope
+
     def model_base
-      if defined?(@model_base)
-        @model_base
-      else
-        ActiveRecord::Base
-      end
+      defined?(@model_base) ? @model_base : ActiveRecord::Base
+    end
+
+    def inbox_scope
+      defined?(@inbox_scope) ? @inbox_scope : -> (messages, user) { messages.by_user(user).active.received }
     end
   end
 end

--- a/lib/discuss/models/discussable.rb
+++ b/lib/discuss/models/discussable.rb
@@ -2,9 +2,15 @@ module Discuss
   module Models
     module Discussable
       # Converts the model into discussable allowing it to interchange messages
-      def acts_as_discussable
-        has_many :messages, class_name: 'Discuss::Message', as: :user
-        include InstanceMethods
+      def self.included(klass)
+        klass.include(InstanceMethods)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def acts_as_discussable
+          has_many :messages, class_name: 'Discuss::Message', as: :user
+        end
       end
 
       module InstanceMethods

--- a/lib/discuss/version.rb
+++ b/lib/discuss/version.rb
@@ -1,3 +1,3 @@
 module Discuss
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
+  include Discuss::Models::Discussable
 
   acts_as_discussable
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov' if ENV['COVERAGE'] != 'off'
 ENV['RAILS_ENV'] = 'test'
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'rails/test_help'
 require 'minitest/autorun'


### PR DESCRIPTION
Example config:

```ruby
# config/initializers/discuss.rb
require_relative '../../app/models/wf/base' # can't use autoload in initializers
require 'discuss/engine'
require Discuss::Engine.root.join('app/models/discuss/message') # can't use autoload in initializers

Discuss.model_base = Wf::Base

Discuss.inbox_scope = -> (messages, wf_student) {
  messages.by_user(wf_student).or(
    messages.where(user_type: 'SchoolClass', user_id: wf_student.school_class_ids)
  ).active.received.order(received_at: :desc)
}
```

No CI for this project, so:

```
$ be rake test
Started with run options --seed 28180

DiscussTest
  test_truth                                                      PASS (0.00s)

message held by multiple threads
  test_0001_can only be sent once                                 PASS (0.08s)

Discuss::RecipientTest
  test_0001_cannot reply if no parent                             PASS (0.03s)
  test_0002_does not deliver if no :body                          PASS (0.04s)
  test_0003_has a parent message                                  PASS (0.02s)

with users
  test_0001_should have a user                                    PASS (0.01s)

with messages
  test_0010_redirects to edit view if unsent?                     PASS (0.17s)
  test_0007_views a sent message                                  PASS (0.04s)
  test_0003_sees drafts                                           PASS (0.05s)
  test_0005_moves a message to trash                              PASS (0.07s)
  test_0011_sends a draft                                         PASS (0.07s)
  test_0014_replies                                               PASS (0.09s)
  test_0008_views a recieved message                              PASS (0.06s)
  test_0009_redirects to show view if uneditable?                 PASS (0.04s)
  test_0006_empties trash                                         PASS (0.06s)
  test_0001_redirects to inbox if message is not mine             PASS (0.04s)
  test_0013_does not see reply form if I sent the message         PASS (0.03s)
  test_0012_edits a draft                                         PASS (0.05s)
  test_0002_sees an outbox                                        PASS (0.03s)
  test_0004_sees trash                                            PASS (0.05s)

sender::when sending
  test_0002_can have multiple recipients                          PASS (0.02s)
  test_0003_sets sent_at but not received_at                      PASS (0.02s)
  test_0005_when trashed, should not be included in the #outbox scope PASS (0.03s)
  test_0004_is included in the #sent scope                        PASS (0.02s)
  test_0001_sends a message by calling #send!                     PASS (0.02s)

sender?::when not message owner
  test_0002_trashes the conversation                              PASS (0.04s)
  test_0001_still find the correct messages                       PASS (0.03s)

with users::when sent
  test_0001_cannot be edited once sent                            PASS (0.02s)
  test_0002_cannot go back to being a draft once sent             PASS (0.02s)

with users::when sent::when received::conversation
  test_0001_has correct recipients size                           PASS (0.04s)

sender::when draft::with recipients
  test_0002_should not deliver the message                        PASS (0.02s)
  test_0003_when trashed, should not be included in the #drafts scope PASS (0.02s)
  test_0001_defaults to draft                                     PASS (0.01s)

Discuss::ConversationTest
  test_0001_has total of 4 messages                               PASS (0.03s)

sender?
  test_0003_drafts                                                PASS (0.02s)
  test_0002_outbox                                                PASS (0.02s)
  test_0004_trash                                                 PASS (0.03s)
  test_0005_can empty_trash!                                      PASS (0.03s)
  test_0001_inbox                                                 PASS (0.02s)

WorkFlowTest
  test_0001_seeing an empty inbox                                 PASS (0.02s)

new message
  test_0002_sends a message                                       PASS (0.05s)
  test_0001_composes a draft                                      PASS (0.05s)

with users::when sent::when received
  test_0001_cannot be edited                                      PASS (0.03s)

sender?
  test_0002_can find all conversation-related messages            PASS (0.04s)
  test_0003_find messages the user owns                           PASS (0.04s)
  test_0004_places messages in the correct mailbox                PASS (0.04s)
  test_0001_has a root                                            PASS (0.04s)

sender::when trashed
  test_0001_still appears in the recipient inbox                  PASS (0.03s)

sender::when draft::without recipients
  test_0001_saved message as draft when no recipients             PASS (0.02s)
  test_0002_does not deliver                                      PASS (0.03s)

recipient?
  test_0001_inbox                                                 PASS (0.04s)
  test_0002_outbox                                                PASS (0.03s)
  test_0003_drafts                                                PASS (0.03s)
  test_0004_trash                                                 PASS (0.03s)
  test_0005_can empty_trash                                       PASS (0.04s)
  test_0003_find messages the user owns                           PASS (0.04s)
  test_0001_has a root                                            PASS (0.04s)
  test_0002_can find all conversation-related messages            PASS (0.03s)
  test_0004_places messages in the correct mailbox                PASS (0.03s)

Discuss::MessageTest
  test_0002_is read! once                                         PASS (0.02s)
  test_0001_must be valid                                         PASS (0.01s)

when replying
  test_0001_reply to sender                                       PASS (0.04s)
  test_0004_has ancestry tree                                     PASS (0.04s)
  test_0002_is delivered to @sender                               PASS (0.04s)
  test_0003_has the reply in the @recipient's outbox              PASS (0.03s)

sender::when deleted
  test_0001_can be deleted                                        PASS (0.03s)
  test_0002_is not included in the #trash scope                   PASS (0.03s)
  test_0003_still appears in the recipient inbox                  PASS (0.03s)

draft
  test_0001_returns proper user depending if there are recipients PASS (0.02s)

Finished in 2.51845s
69 tests, 138 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/greg/Blake/discuss/coverage. 269 / 299 LOC (89.97%) covered.
```