### PR TITLE
[YETI-3113] Block images in user content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec path: '.'
 group :test do
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'launchy'
   gem 'minitest-reporters'
   gem 'pry-byebug'
   gem 'simplecov', require: false

--- a/app/helpers/discuss/application_helper.rb
+++ b/app/helpers/discuss/application_helper.rb
@@ -5,7 +5,7 @@ module Discuss
     end
 
     def markdown(text)
-      html = Redcarpet::Render::HTML.new(escape_html: true, safe_links_only: true)
+      html = Redcarpet::Render::HTML.new(escape_html: true, safe_links_only: true, no_images: true)
       markdown = ::Redcarpet::Markdown.new(html)
       markdown.render(text).html_safe
     end

--- a/test/features/xss_test.rb
+++ b/test/features/xss_test.rb
@@ -32,11 +32,11 @@ class XssTest< FeatureTest
     end
   end
 
-  context 'with malicious img in body' do
-    let(:body) { '<img src="/logout" />' }
+  context 'with malicious img markdown in body' do
+    let(:body) { '![Alt text](/logout)' }
 
     it "message page doesn't logout" do
-      pending "can't test because html_escaping blocks images and capybara doesn't load images triggering the logout"
+      # capybara doesn't load images triggering the logout, so can't test that, just that it's in the DOM
       visit "/discuss/message/#{@message.id}"
 
       within '.body' do

--- a/test/features/xss_test.rb
+++ b/test/features/xss_test.rb
@@ -22,6 +22,7 @@ class XssTest< FeatureTest
       end
     end
 
+    # never a vulnerability here, without markdown processing it was always blocked by Rails
     it "mailbox page doesn't do bad things" do
       visit "/discuss/mailbox/inbox"
 
@@ -31,15 +32,15 @@ class XssTest< FeatureTest
     end
   end
 
-  context 'with malicious iframe in body' do
-    let(:body) { "<iframe/oNloAd=alert('XSS')//>\x3e" }
+  context 'with malicious img in body' do
+    let(:body) { '<img src="/logout" />' }
 
-    # never a vulnerability here, without markdown processing it was always blocked by Rails
-    it "message page doesn't do bad things" do
+    it "message page doesn't logout" do
+      pending "can't test because html_escaping blocks images and capybara doesn't load images triggering the logout"
       visit "/discuss/message/#{@message.id}"
 
       within '.body' do
-        refute page.has_css?('iframe')
+        refute page.has_css?('img')
       end
     end
   end


### PR DESCRIPTION
Images can be used to make recipient's browsers execute GET requests, including in the case of WF logging out. Because images can be entered as Markdown, the html-escaping doesn't block this attack.

A malicious `![Alt text](/logout)` in a message would cause all recipients to be logged out. They'd be unable to delete the message, because they'd be logged out before seeing the delete button. And they'd probably be unable to go to their inbox without being logged out because the preview would show the image.

The attack doesn't work in the test environment because capybara doesn't load the images and trigger the logout, but I've demonstrated it working in one of the apps (don't remember which) and it's loaded into the DOM in the test.