### PR TITLE
[YETI-3113] XSS Fix III: Return of the Fix.

### DIFF
--- a/app/controllers/discuss/application_controller.rb
+++ b/app/controllers/discuss/application_controller.rb
@@ -20,6 +20,10 @@ module Discuss
       flash[key] = message if message.present?
     end
 
+    def shared_root_path
+      main_app.root_path
+    end
+
     private
 
     def recipient_objects

--- a/app/helpers/discuss/application_helper.rb
+++ b/app/helpers/discuss/application_helper.rb
@@ -5,8 +5,8 @@ module Discuss
     end
 
     def markdown(text)
-      markdown = ::Redcarpet::Markdown.new(html)
       html = Redcarpet::Render::Safe.new(no_images: true, no_styles: true, hard_wrap: true)
+      markdown = ::Redcarpet::Markdown.new(html, footnotes: true)
       markdown.render(text).html_safe
     end
   end

--- a/app/helpers/discuss/application_helper.rb
+++ b/app/helpers/discuss/application_helper.rb
@@ -5,8 +5,8 @@ module Discuss
     end
 
     def markdown(text)
-      html = Redcarpet::Render::HTML.new(escape_html: true, safe_links_only: true, no_images: true)
       markdown = ::Redcarpet::Markdown.new(html)
+      html = Redcarpet::Render::Safe.new(no_images: true, no_styles: true, hard_wrap: true)
       markdown.render(text).html_safe
     end
   end


### PR DESCRIPTION
Switch to Safe, disable styles, turn on hard wrap, turn on footnotes.

* Safe implies escape_html and safe_links_only
* Safe adds extra escaping of the block_code function
* escape_html escapes styles, but if there's a way to add them with markdown no_styles will block that
* hard_wrap allows us to insert <br>s with newlines in the copy (previously in textile this was hacked in with <span>s and CSS to make them divs (gross).
* one copy uses footnotes which are a markdown extension