### PR TITLE
[YETI-3176] Limit and validate message body length

### DIFF
--- a/app/models/discuss/message.rb
+++ b/app/models/discuss/message.rb
@@ -10,6 +10,7 @@ module Discuss
     belongs_to :user, polymorphic: true
 
     validates :body, :user, presence: true
+    validates :body, length: { maximum: Discuss.maximum_message_body_chars }
     validate :lock_down_attributes, on: :update
 
     scope :ordered,      -> { order('created_at desc') }

--- a/app/views/discuss/messages/_form.html.erb
+++ b/app/views/discuss/messages/_form.html.erb
@@ -15,7 +15,8 @@
         label: 'Recipients',
         selected: f.object.draft_recipients.map { |r| recipient_json(r) } %>
       <%= f.input :subject %>
-      <%= f.input :body, required: false, label: 'Your message' %>
+      <%= f.input :body, required: false, label: 'Your message', maxlength: Discuss.maximum_message_body_chars %>
+      <p class="small">Maximum message length <%= Discuss.maximum_message_body_chars %> characters.</p>
       <%= f.input :draft, as: :boolean %>
       <%= f.submit 'Send message' %>
     <% end %>

--- a/lib/discuss.rb
+++ b/lib/discuss.rb
@@ -36,12 +36,26 @@ module Discuss
     #
     attr_writer :inbox_scope
 
+    # Override the default char limit on message length:
+    #
+    #     Discuss.maximum_message_body_chars = 2000
+    #
+    # The default value is:
+    #
+    #     Discuss.maximum_message_body_chars = 1200
+    #
+    attr_writer :maximum_message_body_chars
+
     def model_base
       defined?(@model_base) ? @model_base : ActiveRecord::Base
     end
 
     def inbox_scope
       defined?(@inbox_scope) ? @inbox_scope : -> (messages, user) { messages.by_user(user).active.received }
+    end
+
+    def maximum_message_body_chars
+      defined?(@maximum_message_body_chars) ? @maximum_message_body_chars : 1200
     end
   end
 end

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,5 +1,7 @@
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 
+::Discuss.maximum_message_body_chars = 1090
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/features/workflow_test.rb
+++ b/test/features/workflow_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class WorkFlowTest< FeatureTest
-
   it 'seeing an empty inbox' do
     visit "/discuss/mailbox/inbox" # discuss.mailbox_path(:inbox)
     assert page.has_content?('Inbox')
@@ -27,6 +26,10 @@ class WorkFlowTest< FeatureTest
       select 'bart simpsons', from: 'Recipients'
       fill_in 'Subject', with: 'camping trip'
       fill_in 'Your message', with: "who's bringing what?"
+
+      assert page.has_selector?("textarea#message_body[maxlength='#{Discuss.maximum_message_body_chars}']")
+      assert page.has_content?("Maximum message length #{Discuss.maximum_message_body_chars} characters.")
+
       click_on 'Send message'
 
       assert page.has_css?('div.notice')

--- a/test/features/workflow_test.rb
+++ b/test/features/workflow_test.rb
@@ -28,9 +28,23 @@ class WorkFlowTest< FeatureTest
       fill_in 'Subject', with: 'camping trip'
       fill_in 'Your message', with: "who's bringing what?"
       click_on 'Send message'
+
       assert page.has_css?('div.notice')
       assert_equal 1, Discuss::Mailbox.new(@sender).outbox.count
       assert_equal 1, Discuss::Mailbox.new(@recipient).inbox.count
+    end
+
+    it 'does not send an overly long message' do
+      visit '/discuss/message/compose'
+      select 'bart simpsons', from: 'Recipients'
+      fill_in 'Subject', with: 'camping trip'
+      fill_in 'Your message', with: "lorem ipsum " * 91
+      click_on 'Send message'
+
+      assert page.has_css?('p.errors')
+      assert page.has_css?('.message_body.field_with_errors')
+      assert_equal 0, Discuss::Mailbox.new(@sender).outbox.count
+      assert_equal 0, Discuss::Mailbox.new(@recipient).inbox.count
     end
   end
 

--- a/test/unit/discuss/message_test.rb
+++ b/test/unit/discuss/message_test.rb
@@ -4,12 +4,14 @@ module Discuss
   class MessageTest < MiniTest::Spec
     it 'must have body and recipients' do
       message = Message.new()
+
       refute message.valid?
       assert_equal 2, message.errors.count
     end
 
     it "cannot have a body longer than 1200 chars" do
       message = @sender.messages.create(body: 'lorem ipsum ' * 101, draft_recipients: [@recipient])
+
       refute message.valid?
       refute_empty message.errors[:body]
     end

--- a/test/unit/discuss/message_test.rb
+++ b/test/unit/discuss/message_test.rb
@@ -2,10 +2,16 @@ require 'test_helper'
 
 module Discuss
   class MessageTest < MiniTest::Spec
-    it 'must be valid' do
+    it 'must have body and recipients' do
       message = Message.new()
       refute message.valid?
       assert_equal 2, message.errors.count
+    end
+
+    it "cannot have a body longer than 1200 chars" do
+      message = @sender.messages.create(body: 'lorem ipsum ' * 101, draft_recipients: [@recipient])
+      refute message.valid?
+      refute_empty message.errors[:body]
     end
 
     it 'is read! once' do


### PR DESCRIPTION
## What this PR does

WF/discuss messages have no limit on length. There are quite a number of extremely long messages in the database all of which are gibberish (copypasted text from Wikipedia, song lyrics, and most often just random characters pasted over and over again.

This PR adds a limit and validates it on the model. It also adds a limit to the HTML input and a note to users letting them know there's a limit.