### PR TITLE
[YETI-3176] Control message length (subject too)

### DIFF
--- a/app/models/discuss/message.rb
+++ b/app/models/discuss/message.rb
@@ -10,6 +10,7 @@ module Discuss
     belongs_to :user, polymorphic: true
 
     validates :body, :user, presence: true
+    validates :subject, length: { maximum: 255 }
     validates :body, length: { maximum: Discuss.maximum_message_body_chars }
     validate :lock_down_attributes, on: :update
 

--- a/app/views/discuss/messages/_form.html.erb
+++ b/app/views/discuss/messages/_form.html.erb
@@ -14,7 +14,7 @@
         input_html: {class: 'chosen', multiple: true},
         label: 'Recipients',
         selected: f.object.draft_recipients.map { |r| recipient_json(r) } %>
-      <%= f.input :subject %>
+      <%= f.input :subject, maxlength: 255 %>
       <%= f.input :body, required: false, label: 'Your message', maxlength: Discuss.maximum_message_body_chars %>
       <p class="small">Maximum message length <%= Discuss.maximum_message_body_chars %> characters.</p>
       <%= f.input :draft, as: :boolean %>

--- a/test/unit/discuss/message_test.rb
+++ b/test/unit/discuss/message_test.rb
@@ -16,6 +16,13 @@ module Discuss
       refute_empty message.errors[:body]
     end
 
+    it "cannot have a subject longer than 255 chars" do
+      message = @sender.messages.create(subject: 'x' * 256, body: 'lorem ipsum ', draft_recipients: [@recipient])
+
+      refute message.valid?
+      refute_empty message.errors[:subject]
+    end
+
     it 'is read! once' do
       message = @sender.messages.create(body: 'lorem', draft_recipients: [@recipient])
       message.send!


### PR DESCRIPTION
Message form explodes with database exception if subject is longer than 255 chars (max length for postgres varchar field).

This sets a validation in the model.
